### PR TITLE
Fix inference template path resolution

### DIFF
--- a/mlp-digitos/src/server/infer.py
+++ b/mlp-digitos/src/server/infer.py
@@ -1,5 +1,6 @@
 import base64
 import io
+from pathlib import Path
 import numpy as np
 from PIL import Image
 from ..mlp.model import MLP
@@ -7,13 +8,18 @@ from ..mlp.templates import load_templates
 
 class Inference:
     def __init__(self, weights_path='weights.npz', templates_path='templates.npz'):
+        weights_path = Path(weights_path)
+        templates_path = Path(templates_path)
+        if not templates_path.is_absolute():
+            templates_path = weights_path.resolve().parent / templates_path
+
         self.model = MLP()
         w = np.load(weights_path)
         self.model.W1, self.model.b1 = w['W1'], w['b1']
         self.model.W2, self.model.b2 = w['W2'], w['b2']
 
         # templates: (10, 784) en [0,1]
-        self.templates = load_templates(templates_path)
+        self.templates = load_templates(str(templates_path))
 
     @staticmethod
     def _img_to_vector(img: Image.Image) -> np.ndarray:

--- a/mlp-digitos/tests/test_infer_paths.py
+++ b/mlp-digitos/tests/test_infer_paths.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+from src.server.infer import Inference
+
+
+def test_inference_loads_templates_relative_to_weights():
+    repo_root = Path(__file__).resolve().parents[1]
+    prev_cwd = Path.cwd()
+
+    try:
+        os.chdir("/")
+        inf = Inference(str(repo_root / "weights.npz"))
+    finally:
+        os.chdir(prev_cwd)
+
+    assert inf.templates.shape == (10, 784)


### PR DESCRIPTION
### Motivation
- Importing the server or creating an `Inference` instance from a working directory other than the repository root caused `templates.npz` to be looked up relative to the process CWD and raise `FileNotFoundError`.
- The inference path must reliably locate the bundled `templates.npz` next to the configured `weights.npz` to support running the backend from arbitrary working directories.

### Description
- Resolve `templates_path` relative to the `weights_path` when a non-absolute templates path is provided by converting both to `Path` and joining `weights_path.resolve().parent / templates_path`.
- Pass a string path to `load_templates` to keep the loader API consistent and support the new `Path` handling.
- Add a regression test `tests/test_infer_paths.py` that changes the current working directory to `/` and verifies `Inference` still loads the templates successfully.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_infer_paths.py tests/test_forward.py tests/test_backprop.py`, and the three tests passed (`3 passed in 1.31s`).
- Verified importing `src.server.server` from a different CWD succeeds and `s.inf.templates.shape` reports `(10, 784)`.
- Running the full test suite with `PYTHONPATH=. pytest -q` is currently blocked by a missing test dependency (`httpx`) required by `tests/test_api.py` which causes collection to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba123efbf48320abf54c68b024f74d)