### PR TITLE
docs: completar métricas y análisis en 05_resultados.md

### DIFF
--- a/mlp-digitos/docs/05_resultados.md
+++ b/mlp-digitos/docs/05_resultados.md
@@ -8,17 +8,34 @@
 - Conjunto: MNIST (train/val/test)
 
 ## 2. Métricas globales
-Copiar desde `docs/figures/metrics.txt`:
+Fuente: `docs/figures/metrics.txt` y validación regenerada con `weights.npz`.
 
-- **Accuracy (test):** `X.XXXX`
+- **Accuracy (test):** `0.9680`
+- **Error de clasificación (test = 1 - accuracy):** `0.0320` (3.20%)
+- **Accuracy final de validación:** `0.9711`
+  - Métrica regenerada cargando `weights.npz` y evaluando sobre el split de validación (`load_mnist`), debido a que no se encontró log de entrenamiento versionado.
 
 ## 3. Matriz de confusión
 Se adjunta en `docs/figures/confusion_matrix.csv`.
 
-> (Opcional) Si deseas pegarla como tabla, conviértela a Markdown o inserta una imagen generada.
+Observaciones principales (confusiones más frecuentes):
+- **8 → 1**: 6 casos.
+- **0 → 8**: 6 casos.
+- **6 → 5**: 6 casos.
+- También destacan confusiones de 3 con 8 (8 casos) y de 9 con 7 (7 casos).
 
 ## 4. Clasification report
 Extraído de `docs/figures/classification_report.txt` (precision, recall, F1 por clase).
+
+Resumen por clase (F1 más bajos):
+- **Clase 8**: F1 = **0.9485** (el menor). También tiene la menor precisión (0.9367), consistente con varias falsas alarmas hacia otras clases visualmente similares.
+- **Clase 5**: F1 = **0.9556**. Su recall (0.9469) sugiere más falsos negativos que el promedio.
+- **Clase 3**: F1 = **0.9669** (tercer valor más bajo), con confusiones visibles hacia clases de trazos curvos/cerrados.
+
+Posibles causas:
+- Superposición morfológica entre dígitos (por ejemplo, bucles en 8 y formas cercanas en 3/5/9).
+- Variabilidad del trazo manuscrito y grosor de línea.
+- Capacidad limitada del MLP frente a patrones espaciales finos (sin convoluciones).
 
 ## 5. Observaciones
 - El desempeño mejora con más épocas o más neuronas (p.ej., 10 épocas, 256 neuronas).


### PR DESCRIPTION
### Motivation
- Reemplazar el placeholder de métricas en la documentación por valores reales y añadir métricas explícitas para facilitar la interpretación de resultados.
- Añadir un resumen por clase y observaciones de la matriz de confusión para identificar clases con peor desempeño y posibles causas técnicas.

### Description
- Se actualizó `mlp-digitos/docs/05_resultados.md` reemplazando el placeholder de `Accuracy (test)` por `0.9680` y añadiendo el `Error de clasificación (test = 1 - accuracy)` con valor `0.0320`.
- Se agregó la `Accuracy final de validación` regenerada cargando `weights.npz` y evaluando sobre el split de validación, documentada como `0.9711`.
- Se incorporaron 2–3 observaciones extraídas de `docs/figures/confusion_matrix.csv` sobre las confusiones más frecuentes (por ejemplo `8→1`, `0→8`, `6→5`).
- Se añadió un resumen por clase basado en `docs/figures/classification_report.txt` destacando las clases con menor F1 (`8`, `5`, `3`) y posibles causas (superposición morfológica, variabilidad del trazo, limitaciones del MLP).

### Testing
- Se ejecutó un script Python automático que carga `weights.npz` y el split de validación con `load_mnist()` para regenerar las métricas, y obtuvo `val_accuracy=0.9711` y `test_accuracy=0.9680`, completando con éxito la verificación automatizada de las cifras.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c8465d948320972fbbeb8ca82618)