### PR TITLE
docs: agregar flujo real de entrenamiento del MLP y logs de experimentos

### DIFF
--- a/mlp-digitos/docs/06_entrenamiento.md
+++ b/mlp-digitos/docs/06_entrenamiento.md
@@ -1,0 +1,128 @@
+# 06. Flujo real de entrenamiento (`src/mlp/train.py`)
+
+## 1) Resumen del pipeline real
+El script `src/mlp/train.py` implementa un entrenamiento supervisado de un MLP en cuatro fases:
+
+1. **Parseo de argumentos CLI** (hiperparámetros y opciones de datos reales).
+2. **Carga de datos** con `load_mnist()` y división en train/val/test.
+3. **Bucle por épocas**:
+   - entrenamiento por mini-batches,
+   - validación con `val_acc` al final de cada época.
+4. **Evaluación final en test**, guardado de pesos y salida por consola.
+
+---
+
+## 2) División exacta de datos (`src/mlp/data.py`)
+La función `load_mnist()` realiza este flujo:
+
+- Carga MNIST completo (OpenML o fallback local `mnist.npz`).
+- Normaliza píxeles en \\( [0, 1] \\) dividiendo entre 255.
+- Mezcla aleatoriamente con `rng.permutation(seed=42)`.
+- Divide en proporciones fijas:
+  - **train = 80%**
+  - **val = 10%**
+  - **test = 10%**
+
+Con MNIST completo (70,000 muestras), esto queda en:
+
+- **56,000** entrenamiento,
+- **7,000** validación,
+- **7,000** prueba.
+
+> Importante: la división 80/10/10 ocurre **después** de la mezcla aleatoria, por lo que no se conserva el orden original del dataset.
+
+---
+
+## 3) Hiperparámetros de CLI y su impacto
+El script define estos argumentos:
+
+- `--epochs` (int, default `10`): número de pasadas completas sobre el set de entrenamiento.
+  - Más épocas suelen mejorar la convergencia hasta cierto punto.
+  - Demasiadas épocas pueden sobreajustar si no hay regularización.
+
+- `--hidden` (int, default `128`): cantidad de neuronas en la capa oculta del MLP.
+  - Mayor valor = más capacidad representacional.
+  - También incrementa costo computacional y riesgo de sobreajuste.
+
+- `--lr` (float, default `0.1`): tasa de aprendizaje en el paso de actualización.
+  - Alta: converge más rápido, pero puede desestabilizar.
+  - Baja: más estable, pero más lenta y puede quedar subentrenado con pocas épocas.
+
+- `--l2` (float, default `0.0`): factor de regularización L2 en el modelo.
+  - Penaliza pesos grandes para mejorar generalización.
+  - Si es muy alto, puede reducir demasiado la capacidad de ajuste.
+
+- `--batch` (int, default `128`): tamaño de mini-batch.
+  - Batch pequeño: actualizaciones más ruidosas, posible mejor generalización.
+  - Batch grande: gradiente más estable, menos actualizaciones por época.
+
+- `--canvas-dir` (str, default `None`): ruta de muestras reales etiquetadas (`0..9/*.png`) para mezclar con train.
+  - Permite acercar el dominio de entrenamiento a dibujos reales del sistema.
+
+- `--canvas-repeat` (int, default `3`): número de repeticiones de las muestras de `canvas-dir`.
+  - Repondera datos reales dentro del entrenamiento.
+  - Puede mejorar desempeño en dominio real, pero sesgar si hay pocas muestras o mala calidad.
+
+---
+
+## 4) Ciclo por época (implementación real)
+Por cada época `epoch` en `1..epochs`:
+
+1. **Entrenamiento por mini-batches**:
+   - Se generan lotes con `iterate_minibatches(X_train, y_train, batch_size=args.batch, seed=42+epoch)`.
+   - En cada lote:
+     - `forward(Xb)` para obtener probabilidades,
+     - cálculo de pérdida con `loss(probs, one_hot(yb))`,
+     - `backward(cache, one_hot(yb))` para gradientes,
+     - `step(grads, lr=args.lr)` para actualizar pesos.
+
+2. **Validación de época**:
+   - Se evalúa el modelo completo en `X_val`.
+   - Se calcula `val_pred = argmax(val_probs)` y luego `val_acc = mean(val_pred == y_val)`.
+   - Se imprime: `Epoch XX | val_acc=...`.
+
+Al terminar todas las épocas:
+
+3. **Evaluación final en test**:
+   - Se ejecuta inferencia sobre `X_test`.
+   - Se calcula `test_acc` de forma análoga a validación.
+   - Se imprime `Test acc=...`.
+
+4. **Persistencia**:
+   - Se guarda `weights.npz` con `W1`, `b1`, `W2`, `b2`.
+
+---
+
+## 5) Experimentos (configuración vs métricas)
+Se ejecutaron experimentos con el mismo pipeline y división 80/10/10, variando hiperparámetros.
+
+| Experimento | epochs | hidden | lr   | l2  | batch | val_acc (época final) | test_acc |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| A (base) | 5 | 128 | 0.10 | 0.0 | 128 | 0.9437 | 0.9390 |
+| B | 5 | 256 | 0.10 | 0.0 | 128 | 0.9459 | 0.9417 |
+| C | 5 | 128 | 0.05 | 0.0 | 128 | 0.9259 | 0.9183 |
+
+Fuente de métricas: logs en `docs/figures/experiments/*.log`.
+
+### Configuración elegida
+Se propone como configuración recomendada de compromiso:
+
+- `--epochs 5 --hidden 256 --lr 0.1 --l2 0.0 --batch 128`
+
+Justificación:
+- Logró el mejor `val_acc` y `test_acc` dentro de las corridas comparadas.
+- Mantiene un tiempo de entrenamiento similar al baseline.
+- Aumentar capacidad (`hidden`) mejoró desempeño sin cambios adicionales de complejidad del pipeline.
+
+> Nota: si se incorpora `--canvas-dir`, conviene reevaluar esta selección porque cambia la distribución de entrenamiento.
+
+---
+
+## 6) Comandos de referencia
+Ejemplos usados para reproducir los experimentos:
+
+```bash
+PYTHONPATH=src python -m mlp.train --epochs 5 --hidden 128 --lr 0.10 --l2 0.0 --batch 128
+PYTHONPATH=src python -m mlp.train --epochs 5 --hidden 256 --lr 0.10 --l2 0.0 --batch 128
+PYTHONPATH=src python -m mlp.train --epochs 5 --hidden 128 --lr 0.05 --l2 0.0 --batch 128
+```

--- a/mlp-digitos/docs/figures/experiments/exp_h128_lr005_b128_e5.log
+++ b/mlp-digitos/docs/figures/experiments/exp_h128_lr005_b128_e5.log
@@ -1,0 +1,7 @@
+Epoch 01 | val_acc=0.8767
+Epoch 02 | val_acc=0.9000
+Epoch 03 | val_acc=0.9107
+Epoch 04 | val_acc=0.9196
+Epoch 05 | val_acc=0.9259
+Test acc=0.9183
+Pesos guardados en weights.npz

--- a/mlp-digitos/docs/figures/experiments/exp_h128_lr010_b128_e5.log
+++ b/mlp-digitos/docs/figures/experiments/exp_h128_lr010_b128_e5.log
@@ -1,0 +1,7 @@
+Epoch 01 | val_acc=0.9007
+Epoch 02 | val_acc=0.9111
+Epoch 03 | val_acc=0.9243
+Epoch 04 | val_acc=0.9406
+Epoch 05 | val_acc=0.9437
+Test acc=0.9390
+Pesos guardados en weights.npz

--- a/mlp-digitos/docs/figures/experiments/exp_h256_lr010_b128_e5.log
+++ b/mlp-digitos/docs/figures/experiments/exp_h256_lr010_b128_e5.log
@@ -1,0 +1,7 @@
+Epoch 01 | val_acc=0.9017
+Epoch 02 | val_acc=0.9143
+Epoch 03 | val_acc=0.9250
+Epoch 04 | val_acc=0.9406
+Epoch 05 | val_acc=0.9459
+Test acc=0.9417
+Pesos guardados en weights.npz


### PR DESCRIPTION
### Motivation
- Documentar el flujo real de `src/mlp/train.py` para que el equipo entienda el pipeline exacto de entrenamiento y evaluación.
- Explicitar la división de datos y los efectos de los hiperparámetros CLI para reproducibilidad y decisiones de configuración.
- Adjuntar evidencia experimental para justificar la configuración recomendada.

### Description
- Se agregó `mlp-digitos/docs/06_entrenamiento.md` que describe el pipeline real: parseo de argumentos, carga de datos, bucle por épocas, validación por `val_acc`, evaluación final en test y guardado de pesos. 
- Se documenta la división exacta implementada en `load_mnist()` como `80/10/10` después de mezclar aleatoriamente con `rng.permutation(seed=42)`, y los tamaños resultantes esperados para MNIST (56,000 / 7,000 / 7,000). 
- Se explican los hiperparámetros de la CLI (`--epochs`, `--hidden`, `--lr`, `--l2`, `--batch`, `--canvas-dir`, `--canvas-repeat`) y su impacto práctico en la convergencia y generalización. 
- Se añadió una tabla de experimentos (configuración vs `val_acc`/`test_acc`) y se versionaron los logs de las corridas en `mlp-digitos/docs/figures/experiments/*.log` como evidencia de las métricas usadas para la recomendación de configuración. 

### Testing
- Se instaló `pandas` con `python -m pip install pandas -q` para permitir la descarga por `fetch_openml`, y la instalación fue exitosa. 
- Se ejecutaron tres entrenamientos reproducibles con `PYTHONPATH=src python -m mlp.train` usando las configuraciones: `--epochs 5 --hidden 128 --lr 0.10 --l2 0.0 --batch 128`, `--epochs 5 --hidden 256 --lr 0.10 --l2 0.0 --batch 128`, y `--epochs 5 --hidden 128 --lr 0.05 --l2 0.0 --batch 128`, y todas terminaron correctamente guardando `weights.npz`. 
- Los logs generados están en `mlp-digitos/docs/figures/experiments/` y contienen las series de `val_acc` por época y `Test acc` usadas en la tabla, y las ejecuciones indicaron mejoras consistentes al aumentar `hidden` y con `lr=0.1` en las pruebas realizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2cea6e5cc83209ee1d1d35a21592b)