### PR TITLE
docs: añadir evaluación UX y checklist mínima de accesibilidad

### DIFF
--- a/mlp-digitos/docs/08_ux.md
+++ b/mlp-digitos/docs/08_ux.md
@@ -1,0 +1,145 @@
+# 08. Evaluación UX y Accesibilidad de la Interfaz React
+
+## 1) Objetivo
+Evaluar la experiencia de uso de la interfaz actual de práctica de dígitos y definir mejoras de alto impacto/bajo costo para una siguiente iteración.
+
+Componentes evaluados:
+- `frontend/src/App.jsx`
+- `frontend/src/components/DigitCanvas.jsx`
+
+---
+
+## 2) Evaluación UX (estado actual)
+
+### 2.1 Claridad de instrucciones
+**Fortalezas**
+- La pantalla principal comunica bien la tarea: *dibujar el número solicitado y predecir*.
+- Se muestra claramente el dígito objetivo en un bloque visual destacado.
+- Hay ayudas contextuales útiles (consejos de trazo y uso de “Guardar muestra”).
+
+**Hallazgos**
+- Las instrucciones están en varios bloques de texto; para usuarios iniciales (niños/docentes) conviene una guía más secuencial (paso 1, 2, 3).
+- No hay una indicación explícita de “puedes usar mouse o touch” cerca del canvas.
+- “Repetir intento” puede ser ambiguo: no queda completamente claro que conserva el mismo objetivo y limpia el resultado.
+
+**Valoración:** **Buena** (7.5/10), con mejora potencial en estructuración.
+
+---
+
+### 2.2 Tiempos de respuesta percibidos
+**Fortalezas**
+- Se informa estado textual (“Procesando...”, “Guardando muestra...”, “Listo”), lo que reduce incertidumbre.
+- Se presenta latencia numérica en ms al usuario final.
+
+**Hallazgos**
+- En `predict()` no hay `try/catch`; un error de red o backend puede dejar la UX en estado confuso o romper flujo sin feedback claro.
+- Mientras se predice, el botón “Predecir” sigue habilitado (no hay estado `loading` para evitar doble envío).
+- El estado “Listo” se reutiliza para escenarios distintos (inicio, fin exitoso, reinicio), perdiendo precisión semántica.
+
+**Valoración:** **Aceptable** (6.5/10), con mejoras rápidas de robustez perceptual.
+
+---
+
+### 2.3 Legibilidad y contraste
+**Fortalezas**
+- Jerarquía visual razonable: título, panel de objetivo, panel de resultado.
+- Bordes y bloques ayudan a separar información.
+- Área de dibujo con trazo negro sobre fondo blanco: adecuada para el propósito.
+
+**Hallazgos**
+- Hay varios textos en gris (`#666`, `#444`) sobre fondo blanco que pueden quedar justos para WCAG AA en tamaños pequeños.
+- Uso intensivo de estilos inline dificulta escalar un sistema visual consistente (tipografías, contrastes, estados focus/hover/disabled).
+- El estado “¿Correcto?” usa color (verde/rojo); conviene reforzar con iconografía o texto adicional para no depender solo del color.
+
+**Valoración:** **Buena** (7/10), con deuda de accesibilidad visual.
+
+---
+
+### 2.4 Comprensión del feedback
+**Fortalezas**
+- Resultado incluye dígito, confianza y latencia: feedback cuantitativo claro.
+- La evaluación educativa (objetivo, correcto/no, similitud, retroalimentación) es valiosa para aprendizaje.
+
+**Hallazgos**
+- Si backend no devuelve campos educativos, se muestra nota técnica (`match`, `similarity_score`, `feedback`) que puede no ser comprensible para público no técnico.
+- No hay mensajes de estado específicos para lector de pantalla (sin región `aria-live`).
+- Falta graduación más pedagógica cuando hay error (p.ej., “Intenta hacerlo más grande y centrado”).
+
+**Valoración:** **Buena** (7/10), con oportunidad de lenguaje más pedagógico e inclusivo.
+
+---
+
+## 3) Checklist de accesibilidad mínima
+
+> Estado base: evaluación sobre implementación actual.
+
+### 3.1 Etiquetas y roles en botones/canvas
+- [x] Botones con texto visible (“Limpiar”, “Predecir”, “Guardar muestra”).
+- [ ] Canvas con etiqueta accesible (`aria-label`) o texto asociado mediante `aria-describedby`.
+- [ ] Definir rol/descrición para área de dibujo (el canvas por sí solo no comunica semántica suficiente a AT).
+- [ ] Botones con `type="button"` explícito (buena práctica para evitar efectos secundarios en formularios).
+
+### 3.2 Navegación por teclado
+- [x] Botones son focusables por defecto.
+- [ ] Flujo de uso completo con teclado (actualmente dibujar en canvas requiere puntero/touch).
+- [ ] Atajos de teclado mínimos (ej.: `L` limpiar, `P` predecir, `G` guardar) con ayuda visible.
+- [ ] Estado de foco visual claramente perceptible en todos los controles.
+
+### 3.3 Mensajes de estado para lectores de pantalla
+- [ ] Región `aria-live="polite"` para anunciar cambios de estado (“Procesando…”, “Muestra guardada…”).
+- [ ] `aria-live="assertive"` o patrón equivalente para errores críticos.
+- [ ] Mensajes redactados para usuario final (evitar términos internos/técnicos).
+
+---
+
+## 4) Mejoras priorizadas (alto impacto / bajo costo)
+
+### Prioridad 1 — Accesibilidad semántica y feedback robusto
+**Impacto:** Alto | **Costo:** Bajo
+
+1. **Agregar región de estado accesible (`aria-live`)** en `App.jsx`.
+   - Justificación: mejora inmediata para lectores de pantalla y también formaliza feedback de flujo.
+2. **Etiquetar canvas y describir interacción** (`aria-label` + texto asociado).
+   - Justificación: el elemento clave de interacción hoy no se explica semánticamente para AT.
+3. **Normalizar mensajes de estado** para separar: inicio, procesando, éxito, error y vacío.
+   - Justificación: reduce ambigüedad (“Listo” no cubre todo).
+
+### Prioridad 2 — Percepción de rendimiento y prevención de errores
+**Impacto:** Alto | **Costo:** Bajo
+
+4. **Agregar manejo de errores en `predict()`** con `try/catch` y fallback de UI.
+   - Justificación: evita silencios ante fallas de red/backend.
+5. **Deshabilitar botones durante operaciones async** (`predict`/`saveSample`) y mostrar texto de progreso.
+   - Justificación: evita doble envío y transmite control del sistema.
+6. **Indicador visual no bloqueante de carga** (spinner simple o texto con icono).
+   - Justificación: mejora la respuesta percibida sin cambios estructurales.
+
+### Prioridad 3 — Claridad pedagógica y legibilidad
+**Impacto:** Medio-Alto | **Costo:** Bajo
+
+7. **Reescribir instrucciones en formato de pasos (1-2-3)** y renombrar “Repetir intento” a “Intentar de nuevo”.
+   - Justificación: reduce carga cognitiva inicial.
+8. **Aumentar contraste de textos secundarios** y reforzar feedback con texto/icono además del color.
+   - Justificación: mejora accesibilidad visual y comprensión universal.
+9. **Mensajes de ayuda adaptativos** cuando la predicción no sea correcta (tips concretos de trazo/tamaño/centrado).
+   - Justificación: eleva valor didáctico sin tocar modelo.
+
+---
+
+## 5) Plan sugerido de implementación (rápido)
+
+### Sprint corto (1 iteración)
+- **Día 1:** `aria-live`, etiquetado de canvas, ajustes de mensajes.
+- **Día 2:** manejo de errores y estados de carga en `predict()`/`saveSample`.
+- **Día 3:** revisión de contraste y microcopy instruccional.
+
+### Criterios de aceptación UX/accesibilidad
+- Navegación por teclado funcional para todas las acciones disponibles sin dibujo.
+- Estados anunciados por lector de pantalla en eventos clave.
+- Ningún error de red deja la interfaz sin mensaje entendible.
+- Instrucciones iniciales comprensibles en lectura rápida (<10s).
+
+---
+
+## 6) Conclusión
+La interfaz actual ya ofrece una base sólida para práctica de dígitos (objetivo visible, resultado claro, panel educativo), pero puede mejorar de forma significativa con cambios pequeños: semántica accesible, feedback resiliente y claridad instruccional. Estas mejoras no requieren rediseño completo ni cambios de arquitectura, y maximizan impacto para usuarios reales (niños, docentes y personas con tecnologías asistivas).


### PR DESCRIPTION
### Motivation
- Añadir una sección de documentación que evalúa la interfaz React (`frontend/src/App.jsx`, `frontend/src/components/DigitCanvas.jsx`) en términos de claridad de instrucciones, tiempos de respuesta percibidos, legibilidad/contraste y comprensión del feedback, y proponer mejoras priorizadas y un checklist mínimo de accesibilidad.

### Description
- Se creó el archivo `mlp-digitos/docs/08_ux.md` que contiene la evaluación UX, un checklist de accesibilidad (etiquetado/roles, navegación por teclado, mensajes para lectores de pantalla), mejoras priorizadas (alto impacto / bajo costo) y un plan de implementación corto con criterios de aceptación.

### Testing
- Cambio de solo documentación; se verificó la presencia y contenido del fichero con `cd mlp-digitos && git status --short` y `cd mlp-digitos && nl -ba docs/08_ux.md | sed -n '1,240p'`, ambas comprobaciones exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d68f82e88320ba80d67655247bfd)