### PR TITLE
Add multi-mode (digits/vowels) support across frontend and backend

### DIFF
--- a/mlp-digitos/README.md
+++ b/mlp-digitos/README.md
@@ -22,9 +22,12 @@ templates.npz
 
 ## Recolectar muestras reales del canvas
 1. Ejecuta backend y frontend.
-2. Dibuja el número objetivo en la app React.
+2. Selecciona el modo de ejercicio (números / vocales minúsculas / vocales mayúsculas).
+3. Dibuja el símbolo objetivo en la app React.
 3. Si el trazo representa bien al objetivo, presiona **Guardar muestra**.
-4. Las muestras se guardan en `canvas_samples/<digito>/*.png`.
+4. Las muestras se guardan en:
+   - `canvas_samples/<digito>/*.png` para modo números (compatibilidad con entrenamiento actual).
+   - `canvas_samples/<modo>/<etiqueta>/*.png` para vocales.
 
 ## Reentrenar la misma MLP con muestras reales
 python -m src.mlp.train --epochs 15 --hidden 256 --lr 0.1 --canvas-dir canvas_samples --canvas-repeat 3
@@ -51,7 +54,7 @@ Luego abre en el navegador:
 http://localhost:5173
 
 ## Uso del sistema
-El sistema mostrará un dígito objetivo (por ejemplo: “Escribe el número 7”).
+El sistema mostrará un símbolo objetivo según el modo de práctica (por ejemplo: “Escribe el número 7” o “Escribe la vocal a”).
 
 El usuario dibuja el dígito en el canvas.
 
@@ -79,4 +82,3 @@ Puede presionar Nuevo número para continuar practicando.
 - [07 Compatibilidad](docs/07_compatibilidad.md)
 - [08 UX](docs/08_ux.md)
 - [10 Mantenimiento y soporte](docs/10_mantenimiento_soporte.md)
-

--- a/mlp-digitos/frontend/src/App.jsx
+++ b/mlp-digitos/frontend/src/App.jsx
@@ -1,16 +1,33 @@
 import { useState } from "react";
 import DigitCanvas from "./components/DigitCanvas.jsx";
 
+const MODES = {
+  digits: {
+    label: "Números",
+    symbols: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+  },
+  vowels_lower: {
+    label: "Vocales minúsculas",
+    symbols: ["a", "e", "i", "o", "u"],
+  },
+  vowels_upper: {
+    label: "Vocales mayúsculas",
+    symbols: ["A", "E", "I", "O", "U"],
+  },
+};
+
 export default function App() {
   const [status, setStatus] = useState("Listo");
   const [result, setResult] = useState(null);
+  const [mode, setMode] = useState("digits");
 
-  // Dígito objetivo (lo que el niño debe escribir)
-  const [targetDigit, setTargetDigit] = useState(7);
+  // Símbolo objetivo (depende del modo)
+  const [targetSymbol, setTargetSymbol] = useState("7");
 
   function newRandomTarget() {
-    const n = Math.floor(Math.random() * 10);
-    setTargetDigit(n);
+    const symbols = MODES[mode].symbols;
+    const n = Math.floor(Math.random() * symbols.length);
+    setTargetSymbol(symbols[n]);
     setResult(null);
     setStatus("Listo");
   }
@@ -20,21 +37,50 @@ export default function App() {
     setStatus("Listo");
   }
 
-  const showEvaluation = result && result.target_digit !== null && result.target_digit !== undefined;
+  function onModeChange(nextMode) {
+    setMode(nextMode);
+    setTargetSymbol(MODES[nextMode].symbols[0]);
+    setResult(null);
+    setStatus("Listo");
+  }
+
+  const showEvaluation = result && (
+    (result.target_symbol !== null && result.target_symbol !== undefined) ||
+    (result.target_digit !== null && result.target_digit !== undefined)
+  );
+  const titleByMode = mode === "digits" ? "Escribe el número:" : "Escribe la vocal:";
 
   return (
     <div style={{ fontFamily: "system-ui, sans-serif", maxWidth: 900, margin: "24px auto", padding: 16 }}>
-      <h1 style={{ margin: 0 }}>Práctica de escritura de dígitos (MLP)</h1>
+      <h1 style={{ margin: 0 }}>Práctica de escritura (MLP)</h1>
       <p style={{ marginTop: 8, color: "#444" }}>
-        Dibuja el número solicitado, centrado y grande. Luego presiona <b>Predecir</b>.
+        Selecciona el modo de ejercicio, dibuja el símbolo solicitado y presiona <b>Predecir</b>.
       </p>
+
+      <div style={{ display: "flex", gap: 8, margin: "8px 0 14px 0", flexWrap: "wrap" }}>
+        {Object.entries(MODES).map(([key, cfg]) => (
+          <button
+            key={key}
+            onClick={() => onModeChange(key)}
+            style={{
+              padding: "8px 12px",
+              borderRadius: 10,
+              border: mode === key ? "1px solid #1f3d8f" : "1px solid #ccc",
+              background: mode === key ? "#edf2ff" : "white",
+              cursor: "pointer",
+            }}
+          >
+            {cfg.label}
+          </button>
+        ))}
+      </div>
 
       {/* Panel de objetivo */}
       <div style={{ display: "flex", gap: 12, alignItems: "center", margin: "12px 0", flexWrap: "wrap" }}>
         <div style={{ fontSize: 18 }}>
-          Escribe el número:{" "}
+          {titleByMode}{" "}
           <span style={{ fontSize: 28, fontWeight: 800, padding: "2px 10px", border: "1px solid #ddd", borderRadius: 10 }}>
-            {targetDigit}
+            {targetSymbol}
           </span>
         </div>
 
@@ -56,18 +102,18 @@ export default function App() {
       <div style={{ display: "grid", gridTemplateColumns: "1.2fr 0.8fr", gap: 16 }}>
         {/* Canvas */}
         <div style={{ border: "1px solid #ddd", borderRadius: 12, padding: 16 }}>
-          <DigitCanvas onStatus={setStatus} onResult={setResult} targetDigit={targetDigit} />
+          <DigitCanvas onStatus={setStatus} onResult={setResult} targetSymbol={targetSymbol} mode={mode} />
 
           <div style={{ marginTop: 12, color: "#666", fontSize: 14 }}>
             Estado: <b>{status}</b>
           </div>
 
           <div style={{ marginTop: 10, color: "#666", fontSize: 13 }}>
-            Consejos: hazlo grande, centrado y con trazo claro. Para “1” puedes agregar un pequeño gancho arriba (estilo MNIST).
+            Consejos: hazlo grande, centrado y con trazo claro.
           </div>
 
           <div style={{ marginTop: 10, color: "#335", fontSize: 13, background: "#f7f9ff", border: "1px solid #d8e3ff", borderRadius: 10, padding: 10 }}>
-            Usa <b>Guardar muestra</b> cuando el dibujo represente bien al número objetivo. Luego podrás reentrenar la misma MLP con esas muestras reales.
+            Usa <b>Guardar muestra</b> cuando el dibujo represente bien al objetivo del modo actual. Luego podrás reentrenar la red con esas muestras reales.
           </div>
         </div>
 
@@ -95,7 +141,7 @@ export default function App() {
               {showEvaluation && (
                 <div style={{ padding: 12, borderRadius: 12, border: "1px solid #eee", background: "#fafafa" }}>
                   <div style={{ marginBottom: 6 }}>
-                    Objetivo: <b>{result.target_digit}</b>
+                    Objetivo: <b>{result.target_symbol ?? result.target_digit}</b>
                   </div>
 
                   <div style={{ marginBottom: 6 }}>

--- a/mlp-digitos/frontend/src/components/DigitCanvas.jsx
+++ b/mlp-digitos/frontend/src/components/DigitCanvas.jsx
@@ -6,7 +6,7 @@ const CANVAS_H = 224;
 const OUT_W = 28;
 const OUT_H = 28;
 
-export default function DigitCanvas({ onStatus, onResult, targetDigit }) {
+export default function DigitCanvas({ onStatus, onResult, targetSymbol, mode }) {
   const canvasRef = useRef(null);
   const [drawing, setDrawing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -164,15 +164,27 @@ export default function DigitCanvas({ onStatus, onResult, targetDigit }) {
       return;
     }
 
-    const resp = await fetch("/predict", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ image_b64: b64, target_digit: targetDigit }),
-    });
+    try {
+      const resp = await fetch("/predict", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          image_b64: b64,
+          mode,
+          target_symbol: targetSymbol,
+          target_digit: mode === "digits" ? Number(targetSymbol) : null,
+        }),
+      });
 
-    const json = await resp.json();
-    onResult(json);
-    onStatus?.("Listo");
+      const json = await resp.json();
+      if (!resp.ok) {
+        throw new Error(json.detail || "No se pudo predecir");
+      }
+      onResult(json);
+      onStatus?.("Listo");
+    } catch (err) {
+      onStatus?.(`Error de predicción: ${err.message}`);
+    }
   }
 
   async function saveSample() {
@@ -189,7 +201,7 @@ export default function DigitCanvas({ onStatus, onResult, targetDigit }) {
       const resp = await fetch("/samples/save", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ image_b64: b64, label: targetDigit }),
+        body: JSON.stringify({ image_b64: b64, mode, label: targetSymbol }),
       });
 
       const json = await resp.json();
@@ -197,7 +209,7 @@ export default function DigitCanvas({ onStatus, onResult, targetDigit }) {
         throw new Error(json.detail || "No se pudo guardar la muestra");
       }
 
-      onStatus?.(`Muestra guardada para ${json.label}`);
+      onStatus?.(`Muestra guardada para ${json.label} (${json.mode})`);
     } catch (err) {
       onStatus?.(`Error al guardar: ${err.message}`);
     } finally {

--- a/mlp-digitos/src/server/infer.py
+++ b/mlp-digitos/src/server/infer.py
@@ -9,7 +9,7 @@ from ..mlp.templates import load_templates
 
 
 class Inference:
-    def __init__(self, weights_path='weights.npz', templates_path='templates.npz'):
+    def __init__(self, weights_path='weights.npz', templates_path='templates.npz', labels=None):
         weights_path = Path(weights_path)
         templates_path = Path(templates_path)
         if not templates_path.is_absolute():
@@ -19,9 +19,18 @@ class Inference:
         w = np.load(weights_path)
         self.model.W1, self.model.b1 = w['W1'], w['b1']
         self.model.W2, self.model.b2 = w['W2'], w['b2']
+        out_dim = int(self.model.W2.shape[0])
+        if labels is None:
+            labels = [str(i) for i in range(out_dim)]
+        self.labels = [str(x) for x in labels]
+        if len(self.labels) != out_dim:
+            raise ValueError("labels debe tener el mismo tamaño que out_dim del modelo")
+        self.label_to_idx = {label: idx for idx, label in enumerate(self.labels)}
 
-        # templates: (10, 784) en [0,1]
-        self.templates = load_templates(str(templates_path))
+        # templates opcional
+        self.templates = None
+        if templates_path.exists():
+            self.templates = load_templates(str(templates_path))
 
     @staticmethod
     def _img_to_vector(img: Image.Image) -> np.ndarray:
@@ -35,28 +44,34 @@ class Inference:
         den = float(np.linalg.norm(a) * np.linalg.norm(b) + eps)
         return num / den
 
-    def evaluate(self, x_vec: np.ndarray, target_digit: int):
+    def evaluate(self, x_vec: np.ndarray, target_symbol: str):
         # x_vec shape (1,784)
         x = x_vec.flatten()
-        t = self.templates[int(target_digit)].flatten()
+        if self.templates is None:
+            return None
+        idx = self.label_to_idx.get(str(target_symbol))
+        if idx is None:
+            return None
+        t = self.templates[int(idx)].flatten()
 
         sim = self._cosine_similarity(x, t)  # típicamente [0,1] aprox
         # Convertir a 0..100 (clip por seguridad)
         score = float(np.clip(sim, 0.0, 1.0) * 100.0)
         return score
 
-    def predict_from_base64(self, image_b64: str, target_digit: int | None = None):
+    def predict_from_base64(self, image_b64: str, target_symbol: str | None = None):
         raw = base64.b64decode(image_b64)
         img = Image.open(io.BytesIO(raw))
         x = self._img_to_vector(img)
 
         probs, _ = self.model.forward(x)
         probs = probs.flatten()
-        digit = int(np.argmax(probs))
-        conf = float(probs[digit])
+        pred_idx = int(np.argmax(probs))
+        conf = float(probs[pred_idx])
+        symbol = self.labels[pred_idx]
 
         score = None
-        if target_digit is not None:
-            score = self.evaluate(x, target_digit)
+        if target_symbol is not None:
+            score = self.evaluate(x, target_symbol)
 
-        return digit, conf, score
+        return symbol, conf, score

--- a/mlp-digitos/src/server/server.py
+++ b/mlp-digitos/src/server/server.py
@@ -7,13 +7,28 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from .infer import Inference
 from .store import Store
-from typing import Optional
+from typing import Optional, Literal
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent  # .../src
 CLIENT_DIR = ROOT / "client"
 WEIGHTS_PATH = ROOT.parent / "weights.npz"  # repo root/weights.npz
 DB_PATH = ROOT.parent / "logs.db"
 SAMPLES_DIR = ROOT.parent / "canvas_samples"
+WEIGHTS_PATHS = {
+    "digits": ROOT.parent / "weights.npz",
+    "vowels_lower": ROOT.parent / "weights_vowels_lower.npz",
+    "vowels_upper": ROOT.parent / "weights_vowels_upper.npz",
+}
+TEMPLATES_PATHS = {
+    "digits": ROOT.parent / "templates.npz",
+    "vowels_lower": ROOT.parent / "templates_vowels_lower.npz",
+    "vowels_upper": ROOT.parent / "templates_vowels_upper.npz",
+}
+MODE_LABELS = {
+    "digits": [str(i) for i in range(10)],
+    "vowels_lower": ["a", "e", "i", "o", "u"],
+    "vowels_upper": ["A", "E", "I", "O", "U"],
+}
 
 app = FastAPI()
 
@@ -25,47 +40,71 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-inf = Inference(str(WEIGHTS_PATH))
+infer_by_mode = {}
+for mode, path in WEIGHTS_PATHS.items():
+    if path.exists():
+        infer_by_mode[mode] = Inference(
+            str(path),
+            str(TEMPLATES_PATHS[mode]),
+            labels=MODE_LABELS[mode],
+        )
 store = Store(str(DB_PATH), str(SAMPLES_DIR))
 
 class PredictRequest(BaseModel):
     image_b64: str
+    mode: Literal["digits", "vowels_lower", "vowels_upper"] = "digits"
+    target_symbol: Optional[str] = None
     target_digit: Optional[int] = None
 
 
 class SaveSampleRequest(BaseModel):
     image_b64: str
-    label: int
+    mode: Literal["digits", "vowels_lower", "vowels_upper"] = "digits"
+    label: str | int
 
 
 @app.post('/predict')
 async def predict(req: PredictRequest):
     t0 = time.time()
     print("\n === Nueva Peticion ===")
-    print("Target Digit: ", req.target_digit)
+    print("Mode:", req.mode)
+    print("Target symbol: ", req.target_symbol)
+    print("Target digit: ", req.target_digit)
     print("Longitud imagen base64:", len(req.image_b64))
 
     try:
-        digit, conf, score = inf.predict_from_base64(req.image_b64, req.target_digit)
+        inf = infer_by_mode.get(req.mode)
+        if inf is None:
+            raise HTTPException(
+                status_code=503,
+                detail=f"No hay pesos entrenados para el modo '{req.mode}'.",
+            )
+        target_symbol = req.target_symbol
+        if target_symbol is None and req.target_digit is not None and req.mode == "digits":
+            target_symbol = str(req.target_digit)
+        symbol, conf, score = inf.predict_from_base64(req.image_b64, target_symbol)
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
     latency = (time.time() - t0) * 1000.0
-    print("Prediccion: ", digit)
+    print("Prediccion: ", symbol)
     print("Prediccion: ", conf)
     print("Prediccion: ", score)
     print("Prediccion: ", latency)
     print("\n === FIN Peticion ===")
 
-    store.insert(digit, conf, latency)
+    store.insert(req.mode, symbol, conf, latency)
 
     # Feedback mínimo (MVP) basado en target + score + conf
     feedback = None
     match = None
-    if req.target_digit is not None:
-        match = (digit == req.target_digit)
+    expected = target_symbol
+    if expected is not None:
+        match = (symbol == expected)
         if not match:
-            feedback = "Incorrecto. Intenta de nuevo y haz el dígito más grande y centrado."
+            feedback = "Incorrecto. Intenta de nuevo y haz el trazo más grande y centrado."
         else:
             # score suele reflejar “qué tan parecido” al estilo plantilla
             if score is not None and score >= 85:
@@ -76,9 +115,12 @@ async def predict(req: PredictRequest):
                 feedback = "Correcto, pero la forma puede mejorar. Hazlo más claro y completo."
 
     return {
-        "digit": digit,
+        "digit": int(symbol) if req.mode == "digits" and symbol.isdigit() else None,
+        "symbol": symbol,
         "confidence": conf,
         "latency_ms": latency,
+        "mode": req.mode,
+        "target_symbol": expected,
         "target_digit": req.target_digit,
         "match": match,
         "similarity_score": score,
@@ -88,17 +130,20 @@ async def predict(req: PredictRequest):
 
 @app.post('/samples/save')
 async def save_sample(req: SaveSampleRequest):
-    if not 0 <= req.label <= 9:
-        raise HTTPException(status_code=400, detail='label debe estar entre 0 y 9')
+    allowed = set(MODE_LABELS[req.mode])
+    label = str(req.label)
+    if label not in allowed:
+        raise HTTPException(status_code=400, detail=f"label inválida para {req.mode}. Permitidas: {sorted(allowed)}")
 
     try:
-        saved_path = store.save_sample(req.image_b64, req.label)
+        saved_path = store.save_sample(req.image_b64, req.mode, label)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
     return {
         "ok": True,
-        "label": req.label,
+        "mode": req.mode,
+        "label": label,
         "saved_path": saved_path,
     }
 

--- a/mlp-digitos/src/server/store.py
+++ b/mlp-digitos/src/server/store.py
@@ -11,7 +11,8 @@ SCHEMA = """
 CREATE TABLE IF NOT EXISTS logs (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   ts INTEGER,
-  digit INTEGER,
+  mode TEXT,
+  symbol TEXT,
   confidence REAL,
   latency_ms REAL
 );
@@ -22,19 +23,39 @@ class Store:
     def __init__(self, path='logs.db', samples_root='canvas_samples'):
         self.conn = sqlite3.connect(path, check_same_thread=False)
         self.conn.execute(SCHEMA)
+        self._migrate_logs_schema()
         self.conn.commit()
         self.samples_root = Path(samples_root)
         self.samples_root.mkdir(parents=True, exist_ok=True)
 
-    def insert(self, digit: int, conf: float, latency_ms: float):
+    def _migrate_logs_schema(self):
+        cols = {row[1] for row in self.conn.execute("PRAGMA table_info(logs)")}
+        if "mode" not in cols:
+            self.conn.execute("ALTER TABLE logs ADD COLUMN mode TEXT DEFAULT 'digits'")
+        if "symbol" not in cols:
+            self.conn.execute("ALTER TABLE logs ADD COLUMN symbol TEXT")
+
+    def insert(self, mode: str, symbol: str, conf: float, latency_ms: float):
         self.conn.execute(
-            'INSERT INTO logs (ts, digit, confidence, latency_ms) VALUES (?, ?, ?, ?)',
-            (int(time.time()), digit, conf, latency_ms)
+            'INSERT INTO logs (ts, mode, symbol, confidence, latency_ms) VALUES (?, ?, ?, ?, ?)',
+            (int(time.time()), mode, str(symbol), conf, latency_ms)
         )
         self.conn.commit()
 
-    def save_sample(self, image_b64: str, label: int) -> str:
-        label_dir = self.samples_root / str(int(label))
+    def save_sample(self, image_b64: str, mode: str | int, label: str | None = None) -> str:
+        # compatibilidad hacia atrás: save_sample(image_b64, label_int)
+        if label is None:
+            label = str(mode)
+            mode = "digits"
+        else:
+            label = str(label)
+            mode = str(mode)
+
+        if mode == "digits":
+            # compatibilidad con flujo actual de entrenamiento (canvas_samples/0..9)
+            label_dir = self.samples_root / str(label)
+        else:
+            label_dir = self.samples_root / mode / str(label)
         label_dir.mkdir(parents=True, exist_ok=True)
 
         raw = base64.b64decode(image_b64)


### PR DESCRIPTION
### Motivation
- Extend the single-digit handwriting practice app to support multiple exercise modes (numbers, lowercase vowels, uppercase vowels) and enable collecting/using canvas samples per-mode for retraining and evaluation.
- Provide backend support for different trained weights/templates and label sets so predictions, logging and sample saving work for non-digit symbols.

### Description
- Frontend: add `MODES` and UI buttons in `frontend/src/App.jsx` to choose mode, replace `targetDigit` with `targetSymbol`, and pass `mode`/`targetSymbol` to `DigitCanvas`; update labels, messages and result display to support symbols and modes.
- Canvas: update `frontend/src/components/DigitCanvas.jsx` to include `mode`/`targetSymbol` in `/predict` and `/samples/save` requests and adjust request/response handling and error messages.
- Inference: refactor `src/server/infer.py` `Inference` to accept a `labels` list, optionally load templates per-mode, evaluate using label-to-index mapping, and return predicted `symbol` instead of numeric `digit`.
- Server: in `src/server/server.py` register per-mode `WEIGHTS_PATHS`/`TEMPLATES_PATHS`/`MODE_LABELS`, dispatch predictions to per-mode `Inference` instances, validate mode, include `mode` and `target_symbol` in responses, and adapt `/samples/save` to accept `mode` and string labels.
- Storage: update `src/server/store.py` to migrate/add `mode` and `symbol` columns, log `mode`/`symbol` on predictions, and save sample files under `canvas_samples/<mode>/<label>` while keeping compatibility with the original `canvas_samples/<digit>` layout for `digits` mode.
- Docs: update `mlp-digitos/README.md` to document mode selection, sample directories, and adjusted usage texts.

### Testing
- No new automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef34c770c83208b6c49861132f5a4)